### PR TITLE
Feat: Add Helm chart for fcg-usuarios-api deployment

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build
 WORKDIR /src
 
 # Copia somente o necessário do monorepo
-COPY FCG.Usuarios/ ./FCG.Usuarios/
+COPY . ./FCG.Usuarios/
 
 # Restaura dependências e publica
 RUN dotnet restore "FCG.Usuarios/FCG.Usuarios.API/FCG.Usuarios.API.csproj"

--- a/helm/fcg-usuarios-api/Chart.yaml
+++ b/helm/fcg-usuarios-api/Chart.yaml
@@ -1,0 +1,5 @@
+apiVersion: v2
+name: fcg-usuarios-api
+version: 0.1.0
+description: Helm chart for deploying FCG.Usuarios.API (.NET 8)
+type: application

--- a/helm/fcg-usuarios-api/templates/_helpers.tpl
+++ b/helm/fcg-usuarios-api/templates/_helpers.tpl
@@ -1,0 +1,7 @@
+{{- define "fcg-usuarios-api.name" -}}
+fcg-usuarios-api
+{{- end -}}
+
+{{- define "fcg-usuarios-api.fullname" -}}
+{{ .Release.Name }}-{{ include "fcg-usuarios-api.name" . }}
+{{- end -}}

--- a/helm/fcg-usuarios-api/templates/configmap.yaml
+++ b/helm/fcg-usuarios-api/templates/configmap.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.configmap.enabled }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "fcg-usuarios-api.fullname" . }}-config
+  labels:
+    app: {{ include "fcg-usuarios-api.name" . }}
+data:
+{{- range $key, $value := .Values.configmap.data }}
+  {{ $key }}: "{{ $value }}"
+{{- end }}
+{{- end }}

--- a/helm/fcg-usuarios-api/templates/deployment.yaml
+++ b/helm/fcg-usuarios-api/templates/deployment.yaml
@@ -1,0 +1,29 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "fcg-usuarios-api.fullname" . }}
+  labels:
+    app: {{ include "fcg-usuarios-api.name" . }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      app: {{ include "fcg-usuarios-api.name" . }}
+  template:
+    metadata:
+      labels:
+        app: {{ include "fcg-usuarios-api.name" . }}
+    spec:
+      containers:
+        - name: {{ .Chart.Name }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - containerPort: 80
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+          envFrom:
+            - configMapRef:
+                name: {{ include "fcg-usuarios-api.fullname" . }}-config
+            - secretRef:
+                name: {{ include "fcg-usuarios-api.fullname" . }}-secret

--- a/helm/fcg-usuarios-api/templates/hpa.yaml
+++ b/helm/fcg-usuarios-api/templates/hpa.yaml
@@ -1,0 +1,22 @@
+{{- if .Values.hpa.enabled }}
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "fcg-usuarios-api.fullname" . }}
+  labels:
+    app: {{ include "fcg-usuarios-api.name" . }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "fcg-usuarios-api.fullname" . }}
+  minReplicas: {{ .Values.hpa.minReplicas }}
+  maxReplicas: {{ .Values.hpa.maxReplicas }}
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.hpa.targetCPUUtilizationPercentage }}
+{{- end }}

--- a/helm/fcg-usuarios-api/templates/secret.yaml
+++ b/helm/fcg-usuarios-api/templates/secret.yaml
@@ -1,0 +1,13 @@
+{{- if .Values.secret.enabled }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "fcg-usuarios-api.fullname" . }}-secret
+  labels:
+    app: {{ include "fcg-usuarios-api.name" . }}
+type: Opaque
+data:
+{{- range $key, $value := .Values.secret.data }}
+  {{ $key }}: {{ $value | quote }}
+{{- end }}
+{{- end }}

--- a/helm/fcg-usuarios-api/templates/service.yaml
+++ b/helm/fcg-usuarios-api/templates/service.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "fcg-usuarios-api.fullname" . }}
+  labels:
+    app: {{ include "fcg-usuarios-api.name" . }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: 80
+  selector:
+    app: {{ include "fcg-usuarios-api.name" . }}

--- a/helm/fcg-usuarios-api/values.yaml
+++ b/helm/fcg-usuarios-api/values.yaml
@@ -1,0 +1,23 @@
+replicaCount: 1
+image:
+  repository: fabriciorosanet/fcg-usuarios-api
+  tag: latest
+  pullPolicy: IfNotPresent
+service:
+  type: ClusterIP
+  port: 80
+resources: {}
+hpa:
+  enabled: true
+  minReplicas: 1
+  maxReplicas: 5
+  targetCPUUtilizationPercentage: 80
+configmap:
+  enabled: true
+  data:
+    ASPNETCORE_ENVIRONMENT: "Production"
+    CUSTOM_CONFIG: "value"
+secret:
+  enabled: true
+  data:
+    ConnectionStrings__DefaultConnection: "Host=aws-1-us-east-2.pooler.supabase.com;Port=5432;Database=postgres;Username=postgres.elcvczlnnzbgcpsbowkg;Password=Fiap@1234;Ssl Mode=Require;Trust Server Certificate=true;"


### PR DESCRIPTION
Introduces a new Helm chart for deploying the FCG.Usuarios.API (.NET 8) application, including templates for deployment, service, configmap, secret, and HPA. Also updates the Dockerfile to copy the entire context into the build directory.